### PR TITLE
Feature/database interfaces

### DIFF
--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/VerboseUseCaseOutput.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/VerboseUseCaseOutput.groovy
@@ -13,6 +13,7 @@ interface VerboseUseCaseOutput {
      * Sends success notifications that have been
      * recorded during the use case.
      * @param notification containing a success message
+     * @since 1.0.0
      */
     void successNotification(String notification)
 
@@ -20,6 +21,7 @@ interface VerboseUseCaseOutput {
      * Sends failure notifications that have been
      * recorded during the use case.
      * @param notification containing a failure message
+     * @since 1.0.0
      */
     void failNotification(String notification)
 

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliation.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliation.groovy
@@ -1,7 +1,6 @@
 package life.qbic.portal.portlet.customers.affiliation.create
 
 import life.qbic.datamodel.dtos.business.Affiliation
-import life.qbic.portal.portlet.customers.CustomerDbGateway
 
 /**
  * This class implements the Create Affiliations use case.
@@ -13,16 +12,16 @@ import life.qbic.portal.portlet.customers.CustomerDbGateway
  */
 class CreateAffiliation implements CreateAffiliationInput{
 
-    private final CustomerDbGateway customerDbGateway
+    private final CreateAffiliationDataSource dataSource
     private final CreateAffiliationOutput output
 
     /**
      * Creates a use case interactor for creating an affiliation in the provided customer database
-     * @param customerDbGateway the gateway to the database
+     * @param dataSource the gateway to the database
      * @param output an output to publish the results to
      */
-    CreateAffiliation(CreateAffiliationOutput output, CustomerDbGateway customerDbGateway) {
-        this.customerDbGateway = customerDbGateway
+    CreateAffiliation(CreateAffiliationOutput output, CreateAffiliationDataSource dataSource) {
+        this.dataSource = dataSource
         this.output = output
     }
 

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliation.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliation.groovy
@@ -1,6 +1,7 @@
 package life.qbic.portal.portlet.customers.affiliation.create
 
 import life.qbic.datamodel.dtos.business.Affiliation
+import life.qbic.portal.portlet.exceptions.DatabaseQueryException
 
 /**
  * This class implements the Create Affiliations use case.
@@ -28,7 +29,13 @@ class CreateAffiliation implements CreateAffiliationInput{
     /** {@InheritDoc} */
     @Override
     void createAffiliation(Affiliation affiliation) {
-        //TODO implement
-        output.failNotification("Adding affiliations is not implemented yet.")
+        try {
+            dataSource.addAffiliation(affiliation)
+            output.successNotification("Successfully added new affiliation " + affiliation.organisation)
+        } catch (DatabaseQueryException queryException) {
+            throw new DatabaseQueryException(queryException.message)
+        } catch (Exception ignored) {
+            output.failNotification("Could not create new affiliation.")
+        }
     }
 }

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliationDataSource.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliationDataSource.groovy
@@ -1,0 +1,11 @@
+package life.qbic.portal.portlet.customers.affiliation.create
+
+/**
+ * <short description>
+ *
+ * <detailed description>
+ *
+ * @since: <versiontag>
+ */
+interface CreateAffiliationDataSource {
+}

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliationDataSource.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliationDataSource.groovy
@@ -1,5 +1,9 @@
 package life.qbic.portal.portlet.customers.affiliation.create
 
+import life.qbic.datamodel.dtos.business.Affiliation
+import life.qbic.datamodel.dtos.business.Customer
+import life.qbic.portal.portlet.exceptions.DatabaseQueryException
+
 /**
  * <short description>
  *
@@ -8,4 +12,12 @@ package life.qbic.portal.portlet.customers.affiliation.create
  * @since: <versiontag>
  */
 interface CreateAffiliationDataSource {
+    /**
+     * Adds an affiliation to the user database
+     *
+     * @param customer a person to be added to known customers
+     * @throws life.qbic.portal.portlet.exceptions.DatabaseQueryException in case an affiliation could not been added to the customer database
+     * @since 1.0.0
+     */
+    void addAffiliation(Affiliation affiliation) throws DatabaseQueryException
 }

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/list/ListAffiliations.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/list/ListAffiliations.groovy
@@ -1,6 +1,5 @@
 package life.qbic.portal.portlet.customers.affiliation.list
 
-import life.qbic.portal.portlet.customers.CustomerDbGateway
 
 /**
  * This class implements the List Affiliations use case.
@@ -17,23 +16,23 @@ class ListAffiliations implements ListAffiliationsInput {
 
   private final ListAffiliationsOutput output
 
-  private final CustomerDbGateway gateway
+  private final ListAffiliationsDataSource dataSource
 
   /**
    * List Affiliations Use Case
    *
    * Lists the available affiliations for customers.
    * @param output Where the use case submits the result to
-   * @param gateway The database gateway to make the query
+   * @param dataSource The database dataSource to make the query
    */
-  ListAffiliations(ListAffiliationsOutput output, CustomerDbGateway gateway) {
+  ListAffiliations(ListAffiliationsOutput output, ListAffiliationsDataSource dataSource) {
     this.output = output
-    this.gateway = gateway
+    this.dataSource = dataSource
   }
 
   @Override
   void listAffiliations() {
-    def affiliations = gateway.getAllAffiliations()
+    def affiliations = dataSource.listAllAffiliations()
     this.output.reportAvailableAffiliations(affiliations)
   }
 }

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/list/ListAffiliationsDataSource.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/list/ListAffiliationsDataSource.groovy
@@ -1,0 +1,21 @@
+package life.qbic.portal.portlet.customers.affiliation.list
+
+import life.qbic.datamodel.dtos.business.Affiliation
+
+/**
+ * <short description>
+ *
+ * <detailed description>
+ *
+ * @since: <versiontag>
+ */
+interface ListAffiliationsDataSource {
+
+    /**
+     * Fetches all available affiliations from the database
+     *
+     * @return A list of available affiliations
+     * @since 1.0.0
+     */
+    List<Affiliation> listAllAffiliations()
+}

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/create/CreateCustomer.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/create/CreateCustomer.groovy
@@ -1,7 +1,7 @@
 package life.qbic.portal.portlet.customers.create
 
 import life.qbic.datamodel.dtos.business.Customer
-import life.qbic.portal.portlet.customers.CustomerDbGateway
+
 import life.qbic.portal.portlet.exceptions.DatabaseQueryException
 
 /**
@@ -14,19 +14,19 @@ import life.qbic.portal.portlet.exceptions.DatabaseQueryException
  */
 class CreateCustomer implements CreateCustomerInput {
 
-  private CustomerDbGateway customerDbGateway
+  private CreateCustomerDataSource dataSource
   private CreateCustomerOutput output
 
 
-  CreateCustomer(CreateCustomerOutput output, CustomerDbGateway customerDbGateway){
+  CreateCustomer(CreateCustomerOutput output, CreateCustomerDataSource dataSource){
     this.output = output
-    this.customerDbGateway = customerDbGateway
+    this.dataSource = dataSource
   }
 
   @Override
   void createCustomer(Customer customer) {
     try {
-      customerDbGateway.addCustomer(customer)
+      dataSource.addCustomer(customer)
       output.successNotification("Successfully added new customer")
     } catch(DatabaseQueryException databaseQueryException){
       output.failNotification(databaseQueryException.message)

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/create/CreateCustomerDataSource.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/create/CreateCustomerDataSource.groovy
@@ -1,0 +1,22 @@
+package life.qbic.portal.portlet.customers.create
+
+import life.qbic.datamodel.dtos.business.Customer
+import life.qbic.portal.portlet.exceptions.DatabaseQueryException
+
+/**
+ * <short description>
+ *
+ * <detailed description>
+ *
+ * @since: 1.0.0
+ */
+interface CreateCustomerDataSource {
+    /**
+     * Adds a customer to the user database
+     *
+     * @param customer a person to be added to known customers
+     * @throws life.qbic.portal.portlet.exceptions.DatabaseQueryException When a customer could not been added to the customer database
+     * @since 1.0.0
+     */
+    void addCustomer(Customer customer) throws DatabaseQueryException
+}

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/update/UpdateCustomerDataSource.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/update/UpdateCustomerDataSource.groovy
@@ -1,37 +1,25 @@
-package life.qbic.portal.portlet.customers
+package life.qbic.portal.portlet.customers.update
 
-import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.portal.portlet.SearchCriteria
 import life.qbic.portal.portlet.exceptions.DatabaseQueryException
 
 /**
- * A gateway to access information from a customer database
+ * <short description>
  *
- * This class specifies how the application can access external resources.
- * It is meant to be implemented outside the domain layer.
+ * <detailed description>
  *
  * @since: 1.0.0
- * @author: Tobias Koch
- *
  */
-interface CustomerDbGateway {
-
+interface UpdateCustomerDataSource {
     /**
      * This method returns a customer matching the given search criteria
      *
      * @param criteria a map with search criteria
      * @return a person with affiliation and contact information
+     * @since 1.0.0
      */
     List<Customer> findCustomer(SearchCriteria criteria) throws DatabaseQueryException
-
-    /**
-     * Adds a customer to the user database
-     *
-     * @param customer a person to be added to known customers
-     * @throws DatabaseQueryException When a customer could not been added to the customer database
-     */
-    void addCustomer(Customer customer) throws DatabaseQueryException
 
     /**
      * Updates the information of a given customer specified by a customer ID
@@ -40,14 +28,8 @@ interface CustomerDbGateway {
      * @param updatedCustomer customer containing all information and the updates of a customer
      * @throws DatabaseQueryException When a customer could not been updated in the customer
      * database
+     * @since 1.0.0
      */
     void updateCustomer(String customerId, Customer updatedCustomer) throws DatabaseQueryException
-
-    /**
-     * Fetches all available affiliations from the database
-     *
-     * @return A list of available affiliations
-     */
-    List<Affiliation> getAllAffiliations()
 
 }

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/DependencyManager.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/DependencyManager.groovy
@@ -3,7 +3,7 @@ package life.qbic.portal.qoffer2
 import groovy.util.logging.Log4j2
 import life.qbic.datamodel.dtos.business.AcademicTitle
 import life.qbic.datamodel.dtos.business.AffiliationCategory
-import life.qbic.portal.portlet.customers.CustomerDbGateway
+
 import life.qbic.portal.portlet.customers.affiliation.create.CreateAffiliation
 import life.qbic.portal.portlet.customers.create.CreateCustomer
 import life.qbic.portal.qoffer2.customers.CustomerDatabaseQueries
@@ -43,7 +43,7 @@ class DependencyManager {
     private CreateCustomerPresenter createCustomerPresenter
     private CreateAffiliationPresenter createAffiliationPresenter
 
-    private CustomerDbGateway customerDbGateway
+    private CustomerDbConnector customerDbConnector
     private CreateCustomer createCustomer
     private CreateAffiliation createAffiliation
     private CreateCustomerController createCustomerController
@@ -81,7 +81,7 @@ class DependencyManager {
         // setup view models
         try {
             this.viewModel = new ViewModel()
-            viewModel.affiliations.addAll(customerDbGateway.allAffiliations)
+            viewModel.affiliations.addAll(customerDbConnector.listAllAffiliations())
         } catch (Exception e) {
             log.error("Unexpected excpetion during ${ViewModel.getSimpleName()} view model setup.", e)
             throw e
@@ -116,7 +116,7 @@ class DependencyManager {
 
             DatabaseSession.create(user, password, host, port, sqlDatabase)
             CustomerDatabaseQueries queries = new CustomerDatabaseQueries(DatabaseSession.INSTANCE)
-            customerDbGateway = new CustomerDbConnector(queries)
+            customerDbConnector = new CustomerDbConnector(queries)
         } catch (Exception e) {
             log.error("Unexpected exception during customer database connection.", e)
             throw e
@@ -147,8 +147,8 @@ class DependencyManager {
     }
 
     private void setupUseCaseInteractors() {
-        this.createCustomer = new CreateCustomer(createCustomerPresenter, customerDbGateway)
-        this.createAffiliation = new CreateAffiliation(createAffiliationPresenter, customerDbGateway)
+        this.createCustomer = new CreateCustomer(createCustomerPresenter, customerDbConnector)
+        this.createAffiliation = new CreateAffiliation(createAffiliationPresenter, customerDbConnector)
     }
 
     private void setupControllers() {

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDatabaseQueries.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDatabaseQueries.groovy
@@ -341,4 +341,30 @@ class CustomerDatabaseQueries {
         }
         return result
     }
+
+    void addAffiliation(Affiliation affiliation) throws DatabaseQueryException {
+        /*
+        if (affiliationExists) {
+            throw new DatabaseQueryException("Affiliation is already in the database.")
+        }
+        Connection connection = databaseSession.getConnection()
+        connection.setAutoCommit(false)
+
+        connection.withCloseable {it ->
+            try {
+                int customerId = createNewCustomer(it, customer)
+                storeAffiliation(it, customerId, customer.affiliations)
+                connection.commit()
+            } catch (Exception e) {
+                log.error(e.message)
+                log.error(e.stackTrace.join("\n"))
+                connection.rollback()
+                connection.close()
+                throw new DatabaseQueryException("Could not create customer.")
+            }
+
+        }
+        */
+
+    }
 }

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
@@ -98,6 +98,9 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
     databaseQueries.getAffiliations()
   }
 
+  /**
+   *@inheritDoc
+   */
   @Override
   void addAffiliation(Affiliation affiliation) {
     try {

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
@@ -5,8 +5,11 @@ import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.portal.portlet.CriteriaType
 
-import life.qbic.portal.portlet.customers.CustomerDbGateway
 import life.qbic.portal.portlet.SearchCriteria
+import life.qbic.portal.portlet.customers.affiliation.create.CreateAffiliationDataSource
+import life.qbic.portal.portlet.customers.affiliation.list.ListAffiliationsDataSource
+import life.qbic.portal.portlet.customers.create.CreateCustomerDataSource
+import life.qbic.portal.portlet.customers.update.UpdateCustomerDataSource
 import life.qbic.portal.portlet.exceptions.DatabaseQueryException
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -22,7 +25,7 @@ import org.apache.logging.log4j.Logger
  *
  */
 @Log4j2
-class CustomerDbConnector implements CustomerDbGateway {
+class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDataSource, CreateAffiliationDataSource, ListAffiliationsDataSource {
 
   CustomerDatabaseQueries databaseQueries
 
@@ -90,7 +93,7 @@ class CustomerDbConnector implements CustomerDbGateway {
    * @return
    */
   @Override
-  List<Affiliation> getAllAffiliations() {
+  List<Affiliation> listAllAffiliations() {
     databaseQueries.getAffiliations()
   }
 }

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
@@ -6,6 +6,7 @@ import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.portal.portlet.CriteriaType
 
 import life.qbic.portal.portlet.SearchCriteria
+import life.qbic.portal.portlet.customers.affiliation.create.CreateAffiliation
 import life.qbic.portal.portlet.customers.affiliation.create.CreateAffiliationDataSource
 import life.qbic.portal.portlet.customers.affiliation.list.ListAffiliationsDataSource
 import life.qbic.portal.portlet.customers.create.CreateCustomerDataSource
@@ -95,5 +96,18 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
   @Override
   List<Affiliation> listAllAffiliations() {
     databaseQueries.getAffiliations()
+  }
+
+  @Override
+  void addAffiliation(Affiliation affiliation) {
+    try {
+      databaseQueries.addAffiliation(affiliation)
+    } catch (DatabaseQueryException e) {
+      throw new DatabaseQueryException(e.message)
+    } catch (Exception e) {
+      log.error(e)
+      log.error(e.stackTrace.join("\n"))
+      throw new DatabaseQueryException("The affiliation could not be created: ${affiliation.toString()}")
+    }
   }
 }

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/controllers/CreateAffiliationController.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/controllers/CreateAffiliationController.groovy
@@ -1,8 +1,10 @@
 package life.qbic.portal.qoffer2.web.controllers
 
 import groovy.util.logging.Log4j2
+import life.qbic.datamodel.dtos.business.AcademicTitle
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.AffiliationCategory
+import life.qbic.datamodel.dtos.business.AffiliationCategoryFactory
 import life.qbic.portal.portlet.customers.affiliation.create.CreateAffiliationInput
 
 /**
@@ -31,11 +33,22 @@ class CreateAffiliationController {
      * @see AffiliationCategory
      */
     void createAffiliation(String organisation, String addressAddition, String street, String postalCode, String city, String country, String category) {
-        Affiliation
-        //TODO connect to use case
-        // 1. create affiliation form information
-        // 2. call the useCaseInput with the created affiliation
-        log.info("Called the controller for " + useCaseInput)
-        useCaseInput.createAffiliation(null)
+        Affiliation.Builder affiliationBuilder
+        affiliationBuilder = new Affiliation.Builder(organisation, street, postalCode, city)
+        if (addressAddition && addressAddition?.length() > 0) {
+            affiliationBuilder.setAddressAddition(addressAddition)
+        }
+        affiliationBuilder.setCountry(country)
+        AffiliationCategoryFactory categoryFactory = new AffiliationCategoryFactory()
+
+        AffiliationCategory affiliationCategory
+        if (!category || category?.isEmpty()) {
+            affiliationCategory = AffiliationCategory.UNKNOWN
+        } else {
+            affiliationCategory = categoryFactory.getForString(category)
+        }
+        affiliationBuilder.setCategory(affiliationCategory)
+        Affiliation affiliation = affiliationBuilder.build()
+        useCaseInput.createAffiliation(affiliation)
     }
 }


### PR DESCRIPTION
**PR Checklist**

This PR tries to split up the accessibility of the individual use cases away from the `CustomerDBGateway` interface into individual interfaces connotated as `<UseCase>DataSource`  allowing for a more distinct separation pattern. 
Additionally, the `createAffiliation` Use case and Controller are implemented. 
As of now the connection to the database is stubbed and will be addressed in a future PR together with an overhaul of the current documentation of the new methods. 
