### PR TITLE
Remove the unknown setting of an affiliation Category in CustomerDBConnector if no category was set

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
@@ -335,7 +335,7 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
         category = CATEGORY_FACTORY.getForString(row.category as String)
       } catch (IllegalArgumentException ignored) {
         log.warn("Affiliation ${row.id} has category '${row.category}'. Could not match.")
-        throw new DatabaseQueryException("Could not list details for Affiliation ${row.organization}")
+        throw new DatabaseQueryException("Could not list Affiliation details for ${row.organization}")
       }
 
       affiliationBuilder

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
@@ -334,9 +334,7 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
       try {
         category = CATEGORY_FACTORY.getForString(row.category as String)
       } catch (IllegalArgumentException ignored) {
-        //fixme this should not happen but there is an incomplete entry in the DB
         log.warn("Affiliation ${row.id} has category '${row.category}'. Could not match.")
-        category = AffiliationCategory.UNKNOWN
       }
 
       affiliationBuilder

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
@@ -334,7 +334,7 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
       try {
         category = CATEGORY_FACTORY.getForString(row.category as String)
       } catch (IllegalArgumentException ignored) {
-        log.warn("Affiliation ${row.id} has category '${row.category}'. Could not match.")
+        throw new DatabaseQueryException("Affiliation ${row.id} has category '${row.category}'. Could not match.")
       }
 
       affiliationBuilder

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
@@ -334,7 +334,8 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
       try {
         category = CATEGORY_FACTORY.getForString(row.category as String)
       } catch (IllegalArgumentException ignored) {
-        throw new DatabaseQueryException("Affiliation ${row.id} has category '${row.category}'. Could not match.")
+        log.warn("Affiliation ${row.id} has category '${row.category}'. Could not match.")
+        throw new DatabaseQueryException("Could not list details for Affiliation ${row.organization}")
       }
 
       affiliationBuilder


### PR DESCRIPTION
**Description of changes**
This aim of this PR is to remove the access to the outdated `unknown` member of the `Affiliation Category `enum in `qoffer-2-portlet.`
The missing category was updated to `external academic` in the database. 
Misc:
The Exception case is theoretically not necessary anymore, since the category should be determined before adding an entry to the SQL Database
I kept it since i think it makes sense to provide a concise logging to doublecheck the entries during the transition period from one database to another. 

