### PR TITLE
Remove unnecessary toString casting of customerId in CustomerDBConnector

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
@@ -126,7 +126,7 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
 
     connection.withCloseable {
       def statement = it.prepareStatement(query)
-      statement.setString(1, customerId.toString())
+      statement.setInt(1, customerId)
       ResultSet rs = statement.executeQuery()
       while (rs.next()) {
         result.add(rs.getString(1).toInteger())


### PR DESCRIPTION
**Purpose of change**

This PR removes the unnecessary `toString` casting of the `customerId` in the statement generation for the `getAffiliationIdsForPerson `method in `CustomerDBConnector`.

