### PR TITLE
feature/affiliation-service

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/DependencyManager.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/DependencyManager.groovy
@@ -22,6 +22,7 @@ import life.qbic.portal.qoffer2.offers.OfferDbConnector
 import life.qbic.portal.qoffer2.customers.CustomerDbConnector
 import life.qbic.portal.qoffer2.products.ProductsDbConnector
 import life.qbic.portal.qoffer2.database.DatabaseSession
+import life.qbic.portal.qoffer2.services.AffiliationService
 import life.qbic.portal.qoffer2.services.CustomerService
 import life.qbic.portal.qoffer2.web.controllers.CreateAffiliationController
 import life.qbic.portal.qoffer2.web.controllers.CreateOfferController
@@ -103,6 +104,7 @@ class DependencyManager {
     private ConfigurationManager configurationManager
 
     private CustomerService customerService
+    private AffiliationService affiliationService
 
     /**
      * Public constructor.
@@ -161,14 +163,14 @@ class DependencyManager {
     }
 
     private void setupServices() {
-     this.customerService = new CustomerService(customerDbConnector)
-
+        this.customerService = new CustomerService(customerDbConnector)
+        this.affiliationService = new AffiliationService(customerDbConnector)
     }
 
     private void setupViewModels() {
         // setup view models
         try {
-            this.viewModel = new ViewModel()
+            this.viewModel = new ViewModel(affiliationService)
         } catch (Exception e) {
             log.error("Unexpected excpetion during ${ViewModel.getSimpleName()} view model setup.", e)
             throw e
@@ -184,7 +186,7 @@ class DependencyManager {
         }
 
         try {
-            this.createAffiliationViewModel = new CreateAffiliationViewModel()
+            this.createAffiliationViewModel = new CreateAffiliationViewModel(affiliationService)
             createAffiliationViewModel.affiliationCategories.addAll(AffiliationCategory.values().collect{it.value})
         } catch (Exception e) {
             log.error("Unexpected excpetion during ${CreateAffiliationViewModel.getSimpleName()} view model setup.", e)

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/services/AffiliationService.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/services/AffiliationService.groovy
@@ -1,0 +1,34 @@
+package life.qbic.portal.qoffer2.services
+
+import life.qbic.datamodel.dtos.business.Affiliation
+import life.qbic.portal.qoffer2.customers.CustomerDbConnector
+import life.qbic.portal.qoffer2.events.EventEmitter
+
+/**
+ * Customer service that holds resources about available affiliation information
+ * and exposes an event emitter, that can be used to subscribe
+ * to any update event of the underlying affiliation resource data.
+ *
+ * @since 1.0.0
+ */
+class AffiliationService implements Service {
+
+    final private CustomerDbConnector dbConnector
+
+    final private List<Affiliation> availableAffiliations
+
+    final EventEmitter<List<Affiliation>> eventEmitter
+
+    AffiliationService(CustomerDbConnector dbConnector) {
+        this.dbConnector = dbConnector
+        this.availableAffiliations = dbConnector.listAllAffiliations()
+        this.eventEmitter = new EventEmitter<>()
+    }
+
+    @Override
+    void reloadResources() {
+        this.availableAffiliations.clear()
+        this.availableAffiliations.addAll(dbConnector.listAllAffiliations())
+        this.eventEmitter.emit(availableAffiliations.asList())
+    }
+}

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/services/CustomerService.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/services/CustomerService.groovy
@@ -7,8 +7,8 @@ import life.qbic.portal.qoffer2.events.EventEmitter
 
 /**
  * Customer service that holds resources about customer information
- * and can exposes an event emitter, that can be used to subscribe
- * to any update event of the underlying resource data.
+ * and exposes an event emitter, that can be used to subscribe
+ * to any update event of the underlying customer resource data.
  *
  * @since 1.0.0
  */

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/services/CustomerService.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/services/CustomerService.groovy
@@ -1,7 +1,6 @@
 package life.qbic.portal.qoffer2.services
 
 import life.qbic.datamodel.dtos.business.Customer
-
 import life.qbic.portal.qoffer2.customers.CustomerDbConnector
 import life.qbic.portal.qoffer2.events.EventEmitter
 

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/CreateAffiliationPresenter.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/CreateAffiliationPresenter.groovy
@@ -60,11 +60,6 @@ class CreateAffiliationPresenter implements CreateAffiliationOutput {
      */
     @Override
     void affiliationCreated(Affiliation affiliation) {
-        if (affiliation in sharedViewModel.affiliations) {
-            // This behaviour should not appear and should be handled by the use case
-            log.warn("Tried to add already listed affiliation to the view model. This should never happen.")
-        } else {
-            sharedViewModel.affiliations.add(affiliation)
-        }
+        createAffiliationViewModel.affiliationService.reloadResources()
     }
 }

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/viewmodel/CreateAffiliationViewModel.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/viewmodel/CreateAffiliationViewModel.groovy
@@ -2,6 +2,7 @@ package life.qbic.portal.qoffer2.web.viewmodel
 
 import groovy.beans.Bindable
 import life.qbic.datamodel.dtos.business.AffiliationCategory
+import life.qbic.portal.qoffer2.services.Service
 
 /**
  * A ViewModel holding data that is presented in a
@@ -33,4 +34,10 @@ class CreateAffiliationViewModel {
     @Bindable Boolean cityValid
     @Bindable Boolean countryValid
     @Bindable Boolean affiliationCategoryValid
+
+    final Service affiliationService
+
+    CreateAffiliationViewModel(Service affiliationService) {
+        this.affiliationService = affiliationService
+    }
 }

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/viewmodel/ViewModel.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/viewmodel/ViewModel.groovy
@@ -2,6 +2,7 @@ package life.qbic.portal.qoffer2.web.viewmodel
 
 import groovy.beans.Bindable
 import life.qbic.datamodel.dtos.business.Affiliation
+import life.qbic.portal.qoffer2.services.AffiliationService
 
 
 /**
@@ -18,14 +19,32 @@ class ViewModel {
     final ObservableList successNotifications
     final ObservableList failureNotifications
 
-    ViewModel() {
-        this(new ArrayList<Affiliation>(), new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>())
+    final private AffiliationService service
+
+    ViewModel(AffiliationService service) {
+        this(new ArrayList<Affiliation>(),
+                new ArrayList<String>(),
+                new ArrayList<String>(),
+                new ArrayList<String>(),
+                service)
     }
 
-    private ViewModel(List<Affiliation> affiliations, List<String> academicTitles, List<String> successNotifications,
-              List<String> failureNotifications) {
+    private ViewModel(List<Affiliation> affiliations,
+                      List<String> academicTitles,
+                      List<String> successNotifications,
+                      List<String> failureNotifications,
+                      AffiliationService service) {
         this.affiliations = new ObservableList(affiliations)
         this.successNotifications = new ObservableList(successNotifications)
         this.failureNotifications = new ObservableList(failureNotifications)
+        this.service = service
+        /*
+        We register a subscription that will receive a list of affiliations, when
+        the affiliation service emits an update event.
+         */
+        this.service.eventEmitter.register((List<Affiliation> updatedAffiliations) -> {
+            this.affiliations.clear()
+            this.affiliations.addAll(updatedAffiliations)
+        })
     }
 }


### PR DESCRIPTION
This PR adds an affiliation service, that is used to centralized affiliation data.

The service holds a event emitter property, clients can use to subscribe to update events.