### PR TITLE
Add ids for dynamic fields

### DIFF
--- a/qoffer-infrastructure/src/main/resources/offer-template/offer.html
+++ b/qoffer-infrastructure/src/main/resources/offer-template/offer.html
@@ -151,7 +151,7 @@
                         <td class="price-value">2,500.00</td>
                     </tr>
                 </tbody>
-                <tbody id = "costs">
+                <tfoot id = "costs">
                     <tr id = "offer-net" class="total-costs">
                         <td colspan="5" class="cost-summary-field">Estimated total (net):</td>
                         <td id="total-cost-value-net" class="price-value">12,500.00</td>
@@ -164,7 +164,7 @@
                         <td colspan="5" class="cost-summary-field">Estimtated total (VAT included)</td>
                         <td id="final-cost-value" class="price-value">12,500.00</td>
                     </tr>
-                </tbody>
+                </tfoot>
             </table>
         </div>
         <div class="items-outroduction-text">

--- a/qoffer-infrastructure/src/main/resources/offer-template/offer.html
+++ b/qoffer-infrastructure/src/main/resources/offer-template/offer.html
@@ -15,38 +15,38 @@
     <div class="grid-container">
         <div class="header"><img src="offer_header.png"/></div>
         <div class="customer">
-            <div id="cName">Dr. Max Mustermann</div>
-            <div id="cOrganisation">Quantitative Biology Center</div>
-            <div id="cStreet">Auf der Morgenstelle 10</div>
-            <div id="cPostalCode">72076</div>
-            <div id="cCity">Tübingen</div>
-            <div id="cCountry">-</div>
+            <div id="customer-name">Dr. Max Mustermann</div>
+            <div id="customer-organisation">Quantitative Biology Center</div>
+            <div id="customer-street">Auf der Morgenstelle 10</div>
+            <div id="customer-postal-code">72076</div>
+            <div id="customer-city">Tübingen</div>
+            <div id="customer-country">-</div>
         </div>
-        <div class="qbic-affiliation">
+        <div class="project-manager">
             <div class="qbic-ad">Quantitative Biology Center (QBiC) <br> and 
                 Technology Platforms</div>
             
             <div class="small-spacer"></div>
             <div class="info-title">Project manager</div>
-            <div id="pmName">Dr. Doctore Doctores</div>
+            <div id="project-manager-name">Dr. Doctore Doctores</div>
             
-            <div id="pmStreet">Auf der Morgenstelle 20</div>
-            <div id="pmCity">72076 Tübingen</div>
+            <div id="project-manager-street">Auf der Morgenstelle 20</div>
+            <div id="project-manager-city">72076 Tübingen</div>
             
             <div class="small-spacer"></div>
 
-            <div id="pmEmail">doctore.doctores@qbic.uni-tuebingen.de</div>
+            <div id="project-manager-email">doctore.doctores@qbic.uni-tuebingen.de</div>
         </div>
         <div class="small-spacer"></div>
         
         <div class="doctype">Quotation</div>
-        <div class="date">Monday, 7 March 2020</div>
+        <div class="offer-date">Monday, 7 March 2020</div>
 
         <div class="small-spacer"></div>
 
         <div class="common-quote-information">
             <div class="info-title">Reference number</div>
-            <div id="quote-number">ae2a-xxxx-01</div>
+            <div id="offer-identifier">ae2a-xxxx-01</div>
             
             <div class="small-spacer"></div>
             
@@ -56,23 +56,17 @@
             <div class="small-spacer"></div>
             
             <div class="info-title">Delivery time</div>
-            <div id="offer-expiry-date">Approx. 4-8 weeks upon data retrieval.</div>
+            <div id="offer-delivery-time">Approx. 4-8 weeks upon data retrieval.</div>
 
         </div>
         <div class="project-section">
             <div id="project-title">Project title</div>
-            <div class="project-content-topic">Objective</div>
-            <div id="project-objective" class="project-content">Describe what the project is about
-                here. Make sure not to write in too much detail as we want to prevent unauthorized people to get too much knowledge about the project.
+            <div id="project-description" class="project-content">Describe what the project is about
+                here. Make sure not to write in too much detail as we want to prevent unauthorized people to get too much knowledge about the project. <br>
+                Explain the experimental design in detail. <br>
+                Explain in short what analysis will be performed. <br>
+                Describe what is included in the quotation/cost estimation and some general information.
             </div>
-
-            <div class="project-content-topic">Experimental design</div>
-            <div id="experimental-design" class="project-content">Explain the experimental design in detail.</div>
-
-            <div class="project-content-topic">Bioinformatics analysis</div>
-            <div id="analysis" class="project-content">Explain in short what analysis will be performed.</div>
-
-            <div id="quote-description" class="project-content">Describe what is included in the quotation/cost estimation and some general information.</div>
 
             <div class="cost-summary">
                 <div class="">Estimated total (net)</div>
@@ -90,33 +84,33 @@
     <footer>
         <div class="grid-container-footer">
             <div>
-               <strong>Quantitative Biology</br> Center (QBiC)</strong> </br>
-               Dr. Sven Nahnsen </br>
-               Auf der Morgenstelle 10 </br>
+               <strong>Quantitative Biology<br> Center (QBiC)</strong> <br>
+               Dr. Sven Nahnsen <br>
+               Auf der Morgenstelle 10 <br>
                72076 Tübingen
             </div>
             <div>
-                <strong>Institute for Medical Genetics and Applied Genomics (IMGAG)</strong> </br>
-                Prof. Dr. Olaf Rieß </br>
-                Calwerstr. 7 </br>
+                <strong>Institute for Medical Genetics and Applied Genomics (IMGAG)</strong> <br>
+                Prof. Dr. Olaf Rieß <br>
+                Calwerstr. 7 <br>
                 72076 Tübingen
              </div>
             <div>
-                <strong>Institute for Medical Microbiology and Hygiene </br>(MGM)</strong> </br>
-                Prof. Dr. Julia-Stefanie Frick </br>
-                Elfriede-Aulhorn-Str. 6 </br>
+                <strong>Institute for Medical Microbiology and Hygiene <br>(MGM)</strong> <br>
+                Prof. Dr. Julia-Stefanie Frick <br>
+                Elfriede-Aulhorn-Str. 6 <br>
                 72076 Tübingen
             </div>
             <div>
-                <strong>Proteome Center </br>Tübingen (PCT) </strong></br>
-                Prof. Dr. Boris Macek </br>
-                Auf der Morgenstelle 15 </br>
+                <strong>Proteome Center <br>Tübingen (PCT) </strong><br>
+                Prof. Dr. Boris Macek <br>
+                Auf der Morgenstelle 15 <br>
                 72076 Tübingen
             </div>
             <div>
-                <strong>Core Facility for Medical Bioanalytics (CFMB) </strong></br>
-                Prof. Dr. Marius Üffing </br>
-                Elfriede-Aulhorn-Str. 7 </br>
+                <strong>Core Facility for Medical Bioanalytics (CFMB) </strong><br>
+                Prof. Dr. Marius Üffing <br>
+                Elfriede-Aulhorn-Str. 7 <br>
                 72076 Tübingen
             </div>
         </div>
@@ -129,7 +123,8 @@
         </div>
         <div class="items-overview">
             <table id="items-table">
-                    <tr class="header">
+                <thead>
+                    <tr>
                         <th>Pos.</th>
                         <th>Service Description</th>
                         <th class="price-value">Amount</th>
@@ -137,7 +132,9 @@
                         <th class="price-value">Price/Unit (€)</th>
                         <th class="price-value">Total (€)</th>
                     </tr>
-                    <tr class="item">
+                </thead>
+                <tbody id = "product items">
+                    <tr class="product-item">
                         <td>1</td>
                         <td>Geo-redundant raw data and meta-data storage service for ten years.</td>
                         <td class="price-value">40</td>
@@ -145,7 +142,7 @@
                         <td class="price-value">250.00</td>
                         <td class="price-value">10,000.00</td>
                     </tr>
-                    <tr class="item">
+                    <tr class="product-item">
                         <td>2</td>
                         <td>Another data management service</td>
                         <td class="price-value">10</td>
@@ -153,18 +150,21 @@
                         <td class="price-value">250.00</td>
                         <td class="price-value">2,500.00</td>
                     </tr>
-                    <tr class="total-costs">
+                </tbody>
+                <tbody id = "costs">
+                    <tr id = "offer-net" class="total-costs">
                         <td colspan="5" class="cost-summary-field">Estimated total (net):</td>
                         <td id="total-cost-value-net" class="price-value">12,500.00</td>
                     </tr>
-                    <tr class="total-costs">
+                    <tr id = "offer-vat" class="total-costs">
                         <td colspan="5" class="cost-summary-field">VAT (19%):</td>
                         <td id="vat-cost-value" class="price-value">0.00</td>
                     </tr>
-                    <tr class="total-costs">
+                    <tr id = "offer-total" class="total-costs">
                         <td colspan="5" class="cost-summary-field">Estimtated total (VAT included)</td>
                         <td id="final-cost-value" class="price-value">12,500.00</td>
                     </tr>
+                </tbody>
             </table>
         </div>
         <div class="items-outroduction-text">


### PR DESCRIPTION
**Purpose**
This PR makes sure all dynamic fields in the html doc are provided to properly present the offer DTO. This allows to easily load dynamic content into the html template.

**Changes**
The ids are named in a manner to provide consistent naming conventions (separation with a hyphen). Finally, the item table contains now `thead` and `tbody` to allow dynamic adding of table rows for items.

