### PR TITLE
Add Functionality to Abort Customer Creation Button and Abort Affiliation Button

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateAffiliationView.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateAffiliationView.groovy
@@ -312,6 +312,14 @@ class CreateAffiliationView extends VerticalLayout {
 
             this.controller.createAffiliation(organisation, addressAddition, street, postalCode, city, country, category)
         })
+        this.abortButton.addClickListener({ event ->
+            try {
+                clearAllFields()
+            }
+            catch (Exception e) {
+                sharedViewModel.failureNotifications.add("An unexpected error occurred. We apologize for any inconveniences. Please inform us via email to support@qbic.zendesk.com.")
+            }
+        })
     }
 
     private static ComboBox generateAffiliationCategorySelect(List<String> possibleCategories) {
@@ -328,4 +336,28 @@ class CreateAffiliationView extends VerticalLayout {
             An outside affiliation but not academic (i.e. private sector, companies, etc)""".stripIndent(), ContentMode.PREFORMATTED)
         return comboBox
     }
+
+    /**
+     *  Clears User Input from all Fields in the Create Affiliation View and reset validation status of all Fields
+     */
+    private void clearAllFields() {
+        addressAdditionField.clear()
+        affiliationCategoryField.clear()
+        cityField.clear()
+        countryField.clear()
+        organisationField.clear()
+        postalCodeField.clear()
+        streetField.clear()
+
+        createAffiliationViewModel.addressAdditionValid = null
+        createAffiliationViewModel.affiliationCategoryValid = null
+        createAffiliationViewModel.cityValid = null
+        createAffiliationViewModel.countryValid = null
+        createAffiliationViewModel.organisationValid = null
+        createAffiliationViewModel.postalCodeValid = null
+        createAffiliationViewModel.streetValid = null
+
+    }
+
+
 }

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateCustomerView.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateCustomerView.groovy
@@ -370,8 +370,20 @@ class CreateCustomerView extends VerticalLayout {
         })
 
         this.affiliationComboBox.addSelectionListener({
-            fireAffiliationSelectionEvent(it.value)
-            updateAffiliationDetails(it.value)
+            if (it.value != null) {
+                fireAffiliationSelectionEvent(it.value)
+                updateAffiliationDetails(it.value)
+            }
+        })
+
+        this.abortButton.addClickListener({ event ->
+            try {
+                clearAllFields()
+            }
+            catch (Exception e) {
+                log.error("Unexpected error aborting the customer creation.", e)
+                sharedViewModel.failureNotifications.add("An unexpected error occurred. We apologize for any inconveniences. Please inform us via email to support@qbic.zendesk.com.")
+            }
         })
     }
 
@@ -414,5 +426,26 @@ class CreateCustomerView extends VerticalLayout {
     private void fireAffiliationSelectionEvent(Affiliation affiliation) {
         AffiliationSelectionEvent event = new AffiliationSelectionEvent(this, affiliation)
         this.affiliationSelectionListeners.each {it.affiliationSelected(event)}
+    }
+
+    /**
+     *  Clears User Input from all fields in the Create Customer View and reset validation status of all Fields
+     */
+    private void clearAllFields() {
+
+        titleField.clear()
+        firstNameField.clear()
+        lastNameField.clear()
+        emailField.clear()
+        affiliationComboBox.selectedItem = affiliationComboBox.clear()
+        addressAdditionComboBox.selectedItem = addressAdditionComboBox.clear()
+        affiliationDetails.setContent(null)
+
+        createCustomerViewModel.academicTitleValid = null
+        createCustomerViewModel.firstNameValid = null
+        createCustomerViewModel.lastNameValid = null
+        createCustomerViewModel.emailValid = null
+        createCustomerViewModel.affiliationValid = null
+
     }
 }


### PR DESCRIPTION
**Description of changes**
This PR allows the Abort Customer Creation Button and Abort Affiliation Button 
to clear the user input from the respective fields and resets the individual validation status of each field. 

**Additional context**
WIP Will be added tomorrow
