### PR TITLE
Add correct offer identifier to downloaded HTML

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/offers/OfferToPDFConverter.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/offers/OfferToPDFConverter.groovy
@@ -149,7 +149,7 @@ class OfferToPDFConverter implements OfferExporter{
     }
 
     void setQuotationDetails(){
-        htmlContent.getElementById("offer-identifier").text(offer.identifier.toString())
+        htmlContent.getElementById("offer-identifier").text(offer.identifier.identifier)
         htmlContent.getElementById("offer-expiry-date").text(offer.expirationDate.toLocalDate().toString())
         htmlContent.getElementById("offer-date").text(offer.modificationDate.toLocalDate().toString())
     }


### PR DESCRIPTION
**Purpose**
This PR fixes #191

**Changes**
Call the` .identifier` method on the identifier object to obtain the actual identifier as a string.