### PR TITLE
Remove create affiliation button from view

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateCustomerView.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateCustomerView.groovy
@@ -41,7 +41,6 @@ class CreateCustomerView extends VerticalLayout {
     ComboBox<Affiliation> affiliationComboBox
     ComboBox<Affiliation> addressAdditionComboBox
     Button submitButton
-    Button createAffiliationButton
     Button abortButton
     Panel affiliationDetails
 
@@ -86,9 +85,6 @@ class CreateCustomerView extends VerticalLayout {
         addressAdditionComboBox.setCaption("Address Addition")
         addressAdditionComboBox.enabled = false
 
-        this.createAffiliationButton = new Button("Create Affiliation")
-        createAffiliationButton.setIcon(VaadinIcons.INSTITUTION)
-
         this.submitButton = new Button("Create Customer")
         submitButton.setIcon(VaadinIcons.USER_CHECK)
         submitButton.addStyleName(ValoTheme.BUTTON_FRIENDLY)
@@ -117,7 +113,7 @@ class CreateCustomerView extends VerticalLayout {
         VerticalLayout affiliationPanel = new VerticalLayout(affiliationDetails)
         affiliationPanel.setMargin(false)
         affiliationPanel.setComponentAlignment(affiliationDetails, Alignment.TOP_LEFT)
-        HorizontalLayout buttonLayout = new HorizontalLayout(createAffiliationButton, abortButton,
+        HorizontalLayout buttonLayout = new HorizontalLayout(abortButton,
                 submitButton)
         buttonLayout.setMargin(false)
         HorizontalLayout row4 = new HorizontalLayout(affiliationPanel, buttonLayout)

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateOfferView.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateOfferView.groovy
@@ -176,9 +176,6 @@ class CreateOfferView extends FormLayout{
                     getProductItems(viewModel.productItems),
                     viewModel.customerAffiliation)
         })
-        this.createCustomerView.createAffiliationButton.addClickListener({
-            viewHistory.loadNewView(createAffiliationView)
-        })
     }
 
     /**


### PR DESCRIPTION
This PR removes the create affiliation button from the create customer view, as 
this can be easily done by selecting the feature from the top app menu.