### PR TITLE
add vat, net and overheads to db queries

### DIFF
--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/offers/Offer.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/offers/Offer.groovy
@@ -235,7 +235,7 @@ class Offer {
     }
 
     private double determineOverhead() {
-        double overhead = 0.0
+        double overhead
         switch(selectedCustomerAffiliation.category) {
             case AffiliationCategory.INTERNAL:
                 overhead = 0.0


### PR DESCRIPTION
**Purpose of change**
The vat, net prices, and overheads should be stored in the database and be fetched when loading an offer from the DB

**Changes**
The corresponding queries are updated to obtain the values and write them to the database accordingly
