### PR TITLE
Use Roboto font instead of open sans

### DIFF
--- a/qoffer-infrastructure/src/main/resources/offer-template/offer.html
+++ b/qoffer-infrastructure/src/main/resources/offer-template/offer.html
@@ -4,7 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <title>Offer Template</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300&display=swap">
     <link rel="stylesheet" href="stylesheet.css">
 </head>
 <form> 

--- a/qoffer-infrastructure/src/main/resources/offer-template/stylesheet.css
+++ b/qoffer-infrastructure/src/main/resources/offer-template/stylesheet.css
@@ -1,6 +1,6 @@
 
 body {
-    font-family: Open Sans;
+    font-family: Roboto, Helvetica;
 }
 
 @page {


### PR DESCRIPTION
This PR enables proper font family usage when rendering an offer to PDF. 