### PR TITLE
Introduce proper offer retrieval

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/viewmodel/OfferOverviewModel.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/viewmodel/OfferOverviewModel.groovy
@@ -93,7 +93,7 @@ class OfferOverviewModel {
 
     private Optional<Offer> loadOfferInfo() {
         Optional<Offer> offer = selectedOffer
-                .map({ connector.getOffer(it.projectTitle) })
+                .map({ connector.getOffer(it.offerId) })
                 .orElse(Optional.empty())
         return offer
     }


### PR DESCRIPTION
The current offer retrieval is based on the project title only. 

This leads to numerous undesired side-effects. The retrieval is now
based on the offer id, which is supposed to be unique.